### PR TITLE
Handle network response in datamanager

### DIFF
--- a/app/src/main/java/com/mindorks/framework/mvp/data/DataManager.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/data/DataManager.java
@@ -15,18 +15,16 @@
 
 package com.mindorks.framework.mvp.data;
 
-
 import com.mindorks.framework.mvp.data.db.DbHelper;
-import com.mindorks.framework.mvp.data.network.ApiHelper;
+import com.mindorks.framework.mvp.data.network.LoginApiHelper;
 import com.mindorks.framework.mvp.data.prefs.PreferencesHelper;
-
 import io.reactivex.Observable;
 
 /**
  * Created by janisharali on 27/01/17.
  */
 
-public interface DataManager extends DbHelper, PreferencesHelper, ApiHelper {
+public interface DataManager extends DbHelper, PreferencesHelper, LoginApiHelper {
 
     void updateApiHeader(Long userId, String accessToken);
 

--- a/app/src/main/java/com/mindorks/framework/mvp/data/network/LoginApiHelper.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/data/network/LoginApiHelper.java
@@ -1,0 +1,20 @@
+package com.mindorks.framework.mvp.data.network;
+
+import com.mindorks.framework.mvp.data.network.model.LoginRequest;
+import io.reactivex.Observable;
+
+/**
+ * Created on 20/02/17.
+ */
+
+public interface LoginApiHelper {
+
+    Observable<Object> doGoogleLogin(LoginRequest.GoogleLoginRequest request);
+
+    Observable<Object> doFacebookLogin(LoginRequest.FacebookLoginRequest request);
+
+    Observable<Object> doServerLogin(LoginRequest.ServerLoginRequest request);
+
+    Observable<Object> doLogout();
+
+}

--- a/app/src/main/java/com/mindorks/framework/mvp/ui/login/LoginPresenter.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/ui/login/LoginPresenter.java
@@ -67,12 +67,18 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
                 .subscribe(new Consumer<Object>() {
                     @Override
                     public void accept(Object o) throws Exception {
+                        if(!isViewAttached()){
+                            return;
+                        }
                         getMvpView().hideLoading();
                         getMvpView().openMainActivity();
                     }
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
+                        if(!isViewAttached()){
+                            return;
+                        }
                         getMvpView().hideLoading();
 
                         // handle the login error here
@@ -97,12 +103,18 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
                 .subscribe(new Consumer<Object>() {
                     @Override
                     public void accept(Object aVoid) throws Exception {
+                        if(!isViewAttached()){
+                            return;
+                        }
                         getMvpView().hideLoading();
                         getMvpView().openMainActivity();
                     }
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
+                        if(!isViewAttached()){
+                            return;
+                        }
                         getMvpView().hideLoading();
 
                         // handle the login error here
@@ -126,12 +138,18 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
                 .subscribe(new Consumer<Object>() {
                     @Override
                     public void accept(Object aVoid) throws Exception {
+                        if(!isViewAttached()){
+                            return;
+                        }
                         getMvpView().hideLoading();
                         getMvpView().openMainActivity();
                     }
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
+                        if(!isViewAttached()){
+                            return;
+                        }
                         getMvpView().hideLoading();
 
                         // handle the login error here

--- a/app/src/main/java/com/mindorks/framework/mvp/ui/login/LoginPresenter.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/ui/login/LoginPresenter.java
@@ -19,7 +19,6 @@ import com.androidnetworking.error.ANError;
 import com.mindorks.framework.mvp.R;
 import com.mindorks.framework.mvp.data.DataManager;
 import com.mindorks.framework.mvp.data.network.model.LoginRequest;
-import com.mindorks.framework.mvp.data.network.model.LoginResponse;
 import com.mindorks.framework.mvp.ui.base.BasePresenter;
 import com.mindorks.framework.mvp.utils.CommonUtils;
 
@@ -62,36 +61,18 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
         getMvpView().showLoading();
 
         getCompositeDisposable().add(getDataManager()
-                .doServerLoginApiCall(new LoginRequest.ServerLoginRequest(email, password))
+                .doServerLogin(new LoginRequest.ServerLoginRequest(email, password))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Consumer<LoginResponse>() {
+                .subscribe(new Consumer<Object>() {
                     @Override
-                    public void accept(LoginResponse response) throws Exception {
-                        getDataManager().updateUserInfo(
-                                response.getAccessToken(),
-                                response.getUserId(),
-                                DataManager.LoggedInMode.LOGGED_IN_MODE_SERVER,
-                                response.getUserName(),
-                                response.getUserEmail(),
-                                response.getGoogleProfilePicUrl());
-
-                        if(!isViewAttached()) {
-                            return;
-                        }
-
+                    public void accept(Object o) throws Exception {
                         getMvpView().hideLoading();
                         getMvpView().openMainActivity();
-
                     }
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
-
-                        if(!isViewAttached()) {
-                            return;
-                        }
-
                         getMvpView().hideLoading();
 
                         // handle the login error here
@@ -101,6 +82,7 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
                         }
                     }
                 }));
+
     }
 
     @Override
@@ -109,35 +91,18 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
         getMvpView().showLoading();
 
         getCompositeDisposable().add(getDataManager()
-                .doGoogleLoginApiCall(new LoginRequest.GoogleLoginRequest("test1", "test1"))
+                .doGoogleLogin(new LoginRequest.GoogleLoginRequest("test1", "test1"))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Consumer<LoginResponse>() {
+                .subscribe(new Consumer<Object>() {
                     @Override
-                    public void accept(LoginResponse response) throws Exception {
-                        getDataManager().updateUserInfo(
-                                response.getAccessToken(),
-                                response.getUserId(),
-                                DataManager.LoggedInMode.LOGGED_IN_MODE_GOOGLE,
-                                response.getUserName(),
-                                response.getUserEmail(),
-                                response.getGoogleProfilePicUrl());
-
-                        if(!isViewAttached()) {
-                            return;
-                        }
-
+                    public void accept(Object aVoid) throws Exception {
                         getMvpView().hideLoading();
                         getMvpView().openMainActivity();
                     }
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
-
-                        if(!isViewAttached()) {
-                            return;
-                        }
-
                         getMvpView().hideLoading();
 
                         // handle the login error here
@@ -155,35 +120,18 @@ public class LoginPresenter<V extends LoginMvpView> extends BasePresenter<V>
         getMvpView().showLoading();
 
         getCompositeDisposable().add(getDataManager()
-                .doFacebookLoginApiCall(new LoginRequest.FacebookLoginRequest("test3", "test4"))
+                .doFacebookLogin(new LoginRequest.FacebookLoginRequest("test3", "test4"))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Consumer<LoginResponse>() {
+                .subscribe(new Consumer<Object>() {
                     @Override
-                    public void accept(LoginResponse response) throws Exception {
-                        getDataManager().updateUserInfo(
-                                response.getAccessToken(),
-                                response.getUserId(),
-                                DataManager.LoggedInMode.LOGGED_IN_MODE_FB,
-                                response.getUserName(),
-                                response.getUserEmail(),
-                                response.getGoogleProfilePicUrl());
-
-                        if(!isViewAttached()) {
-                            return;
-                        }
-
+                    public void accept(Object aVoid) throws Exception {
                         getMvpView().hideLoading();
                         getMvpView().openMainActivity();
                     }
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
-
-                        if(!isViewAttached()) {
-                            return;
-                        }
-
                         getMvpView().hideLoading();
 
                         // handle the login error here

--- a/app/src/main/java/com/mindorks/framework/mvp/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/ui/main/MainPresenter.java
@@ -18,7 +18,6 @@ package com.mindorks.framework.mvp.ui.main;
 import com.androidnetworking.error.ANError;
 import com.mindorks.framework.mvp.data.DataManager;
 import com.mindorks.framework.mvp.data.db.model.Question;
-import com.mindorks.framework.mvp.data.network.model.LogoutResponse;
 import com.mindorks.framework.mvp.ui.base.BasePresenter;
 
 import java.util.List;
@@ -54,36 +53,36 @@ public class MainPresenter<V extends MainMvpView> extends BasePresenter<V>
     public void onDrawerOptionLogoutClick() {
         getMvpView().showLoading();
 
-        getCompositeDisposable().add(getDataManager().doLogoutApiCall()
+        getCompositeDisposable().add(getDataManager().doLogout()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(new Consumer<LogoutResponse>() {
-                    @Override
-                    public void accept(LogoutResponse response) throws Exception {
-                        if(!isViewAttached()) {
-                            return;
-                        }
+                .subscribe(new Consumer<Object>() {
+                               @Override
+                               public void accept(Object aVoid) throws Exception {
+                                   if(!isViewAttached()) {
+                                       return;
+                                   }
 
-                        getDataManager().setUserAsLoggedOut();
-                        getMvpView().hideLoading();
-                        getMvpView().openLoginActivity();
-                    }
-                }, new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable throwable) throws Exception {
-                        if(!isViewAttached()) {
-                            return;
-                        }
+                                   getMvpView().hideLoading();
+                                   getMvpView().openLoginActivity();
+                               }
+                           },
+                        new Consumer<Throwable>() {
+                            @Override
+                            public void accept(Throwable throwable) throws Exception {
+                                if(!isViewAttached()) {
+                                    return;
+                                }
 
-                        getMvpView().hideLoading();
+                                getMvpView().hideLoading();
 
-                        // handle the login error here
-                        if (throwable instanceof ANError) {
-                            ANError anError = (ANError) throwable;
-                            handleApiError(anError);
-                        }
-                    }
-                }));
+                                // handle the login error here
+                                if (throwable instanceof ANError) {
+                                    ANError anError = (ANError) throwable;
+                                    handleApiError(anError);
+                                }
+                            }
+                        }));
 
     }
 


### PR DESCRIPTION
DataManager does not need to implement ApiHelper. This removes unnecessary implementation of getApiHeader. 
Helper methods to perform login can be extracted to a separate interface(LoginHelper) and implemented by datamanager.  Datamanager will delegate the login tasks to Apihelper.

Presenter only needs to know if login was successful or some error occurred. So I've just returned an emtpy observable in case of successful response.