### PR TITLE
Configure butterknife for app not library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,6 @@
 
 apply plugin: 'com.android.application'
 apply plugin: 'org.greenrobot.greendao'
-apply plugin: 'com.jakewharton.butterknife'
 apply from: '../config/quality/quality.gradle'
 
 android {

--- a/app/src/main/java/com/mindorks/framework/mvp/ui/about/AboutFragment.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/ui/about/AboutFragment.java
@@ -22,7 +22,6 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.mindorks.framework.mvp.R;
-import com.mindorks.framework.mvp.R2;
 import com.mindorks.framework.mvp.ui.base.BaseFragment;
 
 import javax.inject.Inject;
@@ -74,7 +73,7 @@ public class AboutFragment extends BaseFragment implements AboutMvpView {
         });
     }
 
-    @OnClick(R2.id.nav_back_btn)
+    @OnClick(R.id.nav_back_btn)
     void onNavBackClick() {
         getBaseActivity().onFragmentDetached(AboutFragment.class.getSimpleName());
     }

--- a/app/src/main/java/com/mindorks/framework/mvp/ui/main/MainActivity.java
+++ b/app/src/main/java/com/mindorks/framework/mvp/ui/main/MainActivity.java
@@ -38,7 +38,6 @@ import android.widget.TextView;
 
 import com.mindorks.framework.mvp.BuildConfig;
 import com.mindorks.framework.mvp.R;
-import com.mindorks.framework.mvp.R2;
 import com.mindorks.framework.mvp.data.db.model.Question;
 import com.mindorks.framework.mvp.ui.about.AboutFragment;
 import com.mindorks.framework.mvp.ui.base.BaseActivity;
@@ -65,19 +64,19 @@ public class MainActivity extends BaseActivity implements MainMvpView {
     @Inject
     MainMvpPresenter<MainMvpView> mPresenter;
 
-    @BindView(R2.id.toolbar)
+    @BindView(R.id.toolbar)
     Toolbar mToolbar;
 
-    @BindView(R2.id.drawer_view)
+    @BindView(R.id.drawer_view)
     DrawerLayout mDrawer;
 
-    @BindView(R2.id.navigation_view)
+    @BindView(R.id.navigation_view)
     NavigationView mNavigationView;
 
-    @BindView(R2.id.tv_app_version)
+    @BindView(R.id.tv_app_version)
     TextView mAppVersionTextView;
 
-    @BindView(R2.id.cards_container)
+    @BindView(R.id.cards_container)
     SwipePlaceHolderView mCardsContainerView;
 
     private TextView mNameTextView;

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath 'org.greenrobot:greendao-gradle-plugin:3.2.1'
-        classpath 'com.jakewharton:butterknife-gradle-plugin:8.5.1'
     }
 }
 


### PR DESCRIPTION
The current setup has ButterKnife configured for a library project rather than an app project, hence the need for `R2` to refer to the ids. This isn't necessary, and is a bit confusing.